### PR TITLE
Fix download path for debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-influxdb_version: 2.0.3
+influxdb_version: 2.0.4
 debian_arch: amd64
 centos_arch: x86_64
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,8 +4,3 @@
     name: influxd
     state: started
     daemon_reload: true
-
-- name: influxdb restarted
-  systemd:
-    name: influxd
-    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,8 @@
     name: influxd
     state: started
     daemon_reload: true
+
+- name: influxdb restarted
+  systemd:
+    name: influxd
+    state: restarted

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,17 +12,17 @@
       assert:
         that: p.stat.exists
 
-    - name: Assert owner is root
+    - name: Assert owner is influxdb
       assert:
-        that: p.stat.pw_name == "root"
+        that: p.stat.pw_name == "influxdb"
 
-    - name: Assert group is root
+    - name: Assert group is influxdb
       assert:
-        that: p.stat.gr_name == "root"
+        that: p.stat.gr_name == "influxdb"
 
     - name: Enable service
       systemd:
-        name: influxdb
+        name: influxd
         enabled: true
       register: system
 
@@ -32,7 +32,7 @@
 
     - name: Start service
       systemd:
-        name: influxdb
+        name: influxd
         state: started
       register: started_influx
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,8 @@
   file:
     path: /etc/influxdb
     state: directory
-    owner: root
-    group: root
+    owner: influxdb
+    group: influxdb
     mode: 0744
   notify: influxdb started
 
@@ -20,7 +20,7 @@
     path: /etc/default/influxdb2
     regexp: '^(INFLUXD_CONFIG_PATH=).*'
     replace: '\1{{ influxdb_config_path }}'
-  notify: influxdb started
+  notify: influxdb restarted
 
 - name: Create influxdb options
   set_fact:
@@ -30,10 +30,10 @@
   copy:
     content: "{{ influxdb_options | to_nice_yaml }}"
     dest: "{{ influxdb_config_path }}"
-    owner: root
-    group: root
+    owner: influxdb
+    group: influxdb
     mode: 0644
-  notify: influxdb started
+  notify: influxdb restarted
 
 - import_tasks: create-admin.yml
   when: influxdb_admin_user_password is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     path: /etc/default/influxdb2
     regexp: '^(INFLUXD_CONFIG_PATH=).*'
     replace: '\1{{ influxdb_config_path }}'
-  notify: influxdb restarted
+  notify: influxdb started
 
 - name: Create influxdb options
   set_fact:
@@ -33,7 +33,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: influxdb restarted
+  notify: influxdb started
 
 - import_tasks: create-admin.yml
   when: influxdb_admin_user_password is defined

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,3 +1,3 @@
 ---
-influxdb_url: "https://dl.influxdata.com/influxdb/releases/influxdb2-{{ influxdb_version }}_{{ debian_arch }}.deb"
+influxdb_url: "https://dl.influxdata.com/influxdb/releases/influxdb2-{{ influxdb_version }}-{{ debian_arch }}.deb"
 arch: amd64

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,3 +1,3 @@
 ---
-influxdb_url: "https://dl.influxdata.com/influxdb/releases/influxdb2_{{ influxdb_version }}_{{ debian_arch }}.deb"
+influxdb_url: "https://dl.influxdata.com/influxdb/releases/influxdb2-{{ influxdb_version }}_{{ debian_arch }}.deb"
 arch: amd64


### PR DESCRIPTION
The download path is with a "-" and not a "_".
This caused a 404 error trying to download the file.